### PR TITLE
Refactor VMs and Controllers to put logic back into Controllers

### DIFF
--- a/src/GeekPlatform/Controllers/ControllerBase.cs
+++ b/src/GeekPlatform/Controllers/ControllerBase.cs
@@ -44,7 +44,7 @@ namespace GeekPlatform.Controllers
 
             if (model != null)
             {
-                model.User = User;
+                model.FelhasznaloNev = User.Name;
                 model.ControllerNev = controller.RouteData.Values["controller"].ToString();
             }
         }

--- a/src/GeekPlatform/Controllers/ControllerBase.cs
+++ b/src/GeekPlatform/Controllers/ControllerBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GeekPlatform.Models;
+using GeekPlatform.ViewModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -32,6 +33,20 @@ namespace GeekPlatform.Controllers
             }
 
             await base.OnActionExecutionAsync(context, next);
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            base.OnActionExecuted(context);
+
+            var controller = ((Controller) context.Controller);
+            var model = controller.ViewData.Model as ViewModelBase;
+
+            if (model != null)
+            {
+                model.User = User;
+                model.ControllerNev = controller.RouteData.Values["controller"].ToString();
+            }
         }
     }
 }

--- a/src/GeekPlatform/Controllers/HomeController.cs
+++ b/src/GeekPlatform/Controllers/HomeController.cs
@@ -19,7 +19,7 @@ namespace GeekPlatform.Controllers
 
         public IActionResult Index()
         {
-            return View(new HomeViewModel(User));
+            return View(new HomeViewModel());
         }
 
         public IActionResult About()

--- a/src/GeekPlatform/Controllers/JelentkezesController.cs
+++ b/src/GeekPlatform/Controllers/JelentkezesController.cs
@@ -27,15 +27,24 @@ namespace GeekPlatform.Controllers
         // GET: /<controller>/
         public IActionResult Index(bool enrolled)
         {
-            
-            var vm = new JelentkezesViewModel(
-                DbContext.Course
+            var vm = new JelentkezesViewModel();
+            vm.Courses = DbContext.Course
                 .Include(c => c.CourseEnrollment)
                 .ThenInclude(enr => enr.Profile)
                 .Where(s => s.IsActive && s.SignUpDeadline > DateTime.Now)
-                .ToList(), enrolled, User);
+                .ToList()
+                .Select(c => new CourseViewModel
+                {
+                    CourseName = c.CourseName,
+                    Instructor =
+                        string.Join(", ", c.CourseEnrollment.Where(d => d.IsInstructor).Select(d => d.Profile.Name)),
+                    ImgUrl = c.IconFileName,
+                    Description = c.DescriptionShort,
+                    CourseId = c.CourseId,
+                    IsWorkshop = c.IsWorkshop,
+                    IsEnrolled = c.CourseEnrollment.Any(a => a.Profile == User)
+                });
             return View(vm);
-           
         }
 
         public IActionResult Jelentkezes(int Id)

--- a/src/GeekPlatform/Controllers/KurzusAdatokController.cs
+++ b/src/GeekPlatform/Controllers/KurzusAdatokController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,18 +37,41 @@ namespace GeekPlatform.Controllers
                 return BadRequest();
             }
 
-            Course kurzus = DbContext.Course.Where(c => c.IsActive && !c.IsRunning && c.CourseId == id).FirstOrDefault();
+            Course kurzus = DbContext.Course
+                .Include(c => c.CourseEnrollment).ThenInclude(ce => ce.Profile)
+                .Include(c => c.CourseThematics)
+                .FirstOrDefault(c => c.IsActive && !c.IsRunning && c.CourseId == id);
 
             if (kurzus == null)
             {
                 return NotFound();
             }
-
-            IEnumerable<CourseEnrollment> jelentkezesek = DbContext.CourseEnrollment
-                .Include(ce => ce.Course)
-                .Include(ce => ce.Profile);            
+            
             IEnumerable<CourseThematics> tematika = DbContext.CourseThematics;
-            KurzusAdatokViewModel viewModel = new KurzusAdatokViewModel(kurzus, jelentkezesek, tematika);
+            KurzusAdatokViewModel viewModel = new KurzusAdatokViewModel
+            {
+                Nev = kurzus.CourseName,
+                Leiras = kurzus.DescriptionLong,
+                Oktatok = kurzus.CourseEnrollment
+                    .Where(enrollment => enrollment.IsInstructor)
+                    .Select(p => p.Profile)
+                    .ToList()
+                    .Select(o => new OktatoViewModel
+                    {
+                        Nev = o.Name,
+                        EMail = o.Email,
+                        Pozicio = o.Workplace,
+                        Telefon = o.PhoneNumber
+                    }),
+                KurzusTematika = kurzus.CourseThematics
+                    .ToList()
+                    .Select(t => new KurzusTematikaViewModel
+                    {
+                        Datum = t.ActualDate.ToString("d"),
+                        Het = t.WeekNumber,
+                        Leiras = t.Description
+                    })
+            };
             return View(viewModel);
 
         }

--- a/src/GeekPlatform/Controllers/KurzusAdatokController.cs
+++ b/src/GeekPlatform/Controllers/KurzusAdatokController.cs
@@ -47,7 +47,7 @@ namespace GeekPlatform.Controllers
                 .Include(ce => ce.Course)
                 .Include(ce => ce.Profile);            
             IEnumerable<CourseThematics> tematika = DbContext.CourseThematics;
-            KurzusAdatokViewModel viewModel = new KurzusAdatokViewModel(kurzus, jelentkezesek, tematika, User);
+            KurzusAdatokViewModel viewModel = new KurzusAdatokViewModel(kurzus, jelentkezesek, tematika);
             return View(viewModel);
 
         }

--- a/src/GeekPlatform/Controllers/KurzusaimController.cs
+++ b/src/GeekPlatform/Controllers/KurzusaimController.cs
@@ -33,7 +33,29 @@ namespace GeekPlatform.Controllers
            
             IEnumerable<Course> passzivKurzusok = kurzusok.Where(c => !c.IsRunning).ToList();
 
-            KurzusaimViewModel vm = new KurzusaimViewModel(aktivKurzusok, passzivKurzusok);
+            KurzusaimViewModel vm = new KurzusaimViewModel
+            {
+                AktivKurzusok = aktivKurzusok.Select(c => new KurzusViewModel
+                {
+                    AktualisTematika = new KurzusTematikaViewModel
+                    {
+                        Datum = c.CourseThematics.LastOrDefault(t => t.ActualDate < DateTime.Now)?.ActualDate.ToString("g"),
+                        Temakor = c.CourseThematics.LastOrDefault(t => t.ActualDate < DateTime.Now)?.Title
+                    },
+                    KovetkezoTematika = new KurzusTematikaViewModel
+                    {
+                        Datum = c.CourseThematics.LastOrDefault(t => t.ActualDate > DateTime.Now)?.ActualDate.ToString("g"),
+                        Temakor = c.CourseThematics.LastOrDefault(t => t.ActualDate > DateTime.Now)?.Title
+                    },
+                    Leiras = c.DescriptionLong,
+                    Nev = c.CourseName
+                }),
+                PasszivKurzusok = passzivKurzusok.Select(c => new KurzusViewModel
+                {
+                    Leiras = c.DescriptionLong,
+                    Nev = c.CourseName
+                })
+            };
 
             return View(vm);
         }

--- a/src/GeekPlatform/Controllers/KurzusaimController.cs
+++ b/src/GeekPlatform/Controllers/KurzusaimController.cs
@@ -33,7 +33,7 @@ namespace GeekPlatform.Controllers
            
             IEnumerable<Course> passzivKurzusok = kurzusok.Where(c => !c.IsRunning).ToList();
 
-            KurzusaimViewModel vm = new KurzusaimViewModel(aktivKurzusok, passzivKurzusok, User);
+            KurzusaimViewModel vm = new KurzusaimViewModel(aktivKurzusok, passzivKurzusok);
 
             return View(vm);
         }

--- a/src/GeekPlatform/ViewModels/Home/HomeViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Home/HomeViewModel.cs
@@ -8,7 +8,7 @@ namespace GeekPlatform.ViewModels.Home
 {
     public class HomeViewModel : ViewModelBase
     {
-        public HomeViewModel(Profile user) : base(user)
+        public HomeViewModel()
         {
         }
     }

--- a/src/GeekPlatform/ViewModels/Jelentkezes/CourseViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Jelentkezes/CourseViewModel.cs
@@ -6,22 +6,12 @@ namespace GeekPlatform.ViewModels.Jelentkezes
 {
     public class CourseViewModel
     {
-        public CourseViewModel(Course c, Profile p)
-        {
-            CourseName = c.CourseName;
-            Instructor = string.Join(", ", c.CourseEnrollment.Where(d => d.IsInstructor).Select(d => d.Profile.Name));
-            ImgUrl = c.IconFileName;
-            Description = c.DescriptionShort;
-            CourseId = c.CourseId;
-            IsWorkshop = c.IsWorkshop;
-            IsEnrolled = c.CourseEnrollment.Any(a => a.Profile == p);
-        }
-        public string CourseName { get; }
-        public string Instructor { get; }
-        public string ImgUrl { get; }
-        public string Description { get; }
-        public int CourseId { get; }
-        public  bool IsWorkshop { get; }
-        public bool IsEnrolled { get; }
+        public string CourseName { get; set; }
+        public string Instructor { get; set; }
+        public string ImgUrl { get; set; }
+        public string Description { get; set; }
+        public int CourseId { get; set; }
+        public  bool IsWorkshop { get; set; }
+        public bool IsEnrolled { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Jelentkezes/JelentkezesViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Jelentkezes/JelentkezesViewModel.cs
@@ -10,7 +10,7 @@ namespace GeekPlatform.ViewModels.Jelentkezes
 {
     public class JelentkezesViewModel : ViewModelBase
     {
-        public JelentkezesViewModel(IEnumerable<Course> courselist, bool enrolled, Profile p) : base(p)
+        public JelentkezesViewModel(IEnumerable<Course> courselist, bool enrolled, Profile p)
         {
             Courses = courselist.Select(x => new CourseViewModel(x, p)).ToList();
             Enrolled = enrolled;

--- a/src/GeekPlatform/ViewModels/Jelentkezes/JelentkezesViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Jelentkezes/JelentkezesViewModel.cs
@@ -10,13 +10,8 @@ namespace GeekPlatform.ViewModels.Jelentkezes
 {
     public class JelentkezesViewModel : ViewModelBase
     {
-        public JelentkezesViewModel(IEnumerable<Course> courselist, bool enrolled, Profile p)
-        {
-            Courses = courselist.Select(x => new CourseViewModel(x, p)).ToList();
-            Enrolled = enrolled;
-        }
-        public IList<CourseViewModel> Courses { get; }
-        public bool Enrolled { get; }
+        public IEnumerable<CourseViewModel> Courses { get; set; }
+        public bool Enrolled { get; set; }
     }
 
 }

--- a/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusAdatokViewModel.cs
+++ b/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusAdatokViewModel.cs
@@ -14,8 +14,7 @@ namespace GeekPlatform.ViewModels.KurzusAdatok
         public IEnumerable<OktatoViewModel> Oktatok { get; }
         public IEnumerable<KurzusTematikaViewModel> KurzusTematika { get; }
 
-        public KurzusAdatokViewModel(Course kurzus, IEnumerable<CourseEnrollment> jelentkezesek, IEnumerable<CourseThematics> tematika, Profile user)
-            :base(user)
+        public KurzusAdatokViewModel(Course kurzus, IEnumerable<CourseEnrollment> jelentkezesek, IEnumerable<CourseThematics> tematika)
         {
             Nev = kurzus.CourseName;
             Leiras = kurzus.DescriptionLong;

--- a/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusAdatokViewModel.cs
+++ b/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusAdatokViewModel.cs
@@ -9,22 +9,9 @@ namespace GeekPlatform.ViewModels.KurzusAdatok
 {
     public class KurzusAdatokViewModel : ViewModelBase
     {
-        public String Nev { get; }
-        public String Leiras { get; }
-        public IEnumerable<OktatoViewModel> Oktatok { get; }
-        public IEnumerable<KurzusTematikaViewModel> KurzusTematika { get; }
-
-        public KurzusAdatokViewModel(Course kurzus, IEnumerable<CourseEnrollment> jelentkezesek, IEnumerable<CourseThematics> tematika)
-        {
-            Nev = kurzus.CourseName;
-            Leiras = kurzus.DescriptionLong;
-            IEnumerable<Profile> oktatoResztvevok = jelentkezesek
-                .Where(enrollment => enrollment.IsInstructor
-                    && enrollment.CourseId == kurzus.CourseId)
-                .Select(p => p.Profile);
-            Oktatok = oktatoResztvevok.Select(o => new OktatoViewModel(o)).ToList();
-            IEnumerable<CourseThematics> kurzusTematikaLista = tematika.Where(thematics => thematics.CourseId == kurzus.CourseId);
-            KurzusTematika = kurzusTematikaLista.Select(t => new KurzusTematikaViewModel(t)).ToList();
-        }
+        public String Nev { get; set; }
+        public String Leiras { get; set; }
+        public IEnumerable<OktatoViewModel> Oktatok { get; set; }
+        public IEnumerable<KurzusTematikaViewModel> KurzusTematika { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusTematikaViewModel.cs
+++ b/src/GeekPlatform/ViewModels/KurzusAdatok/KurzusTematikaViewModel.cs
@@ -8,15 +8,8 @@ namespace GeekPlatform.ViewModels.KurzusAdatok
 {
     public class KurzusTematikaViewModel
     {
-        public int Het { get; }
-        public String Datum { get; }
-        public String Leiras { get; }
-
-        public KurzusTematikaViewModel(CourseThematics tematika)
-        {
-            this.Het = tematika.WeekNumber;            
-            this.Datum = tematika.ActualDate.Year.ToString() + "." + tematika.ActualDate.Month.ToString("00") + "." + tematika.ActualDate.Day.ToString("00") + ".";
-            this.Leiras = tematika.Description;
-        }
+        public int Het { get; set; }
+        public String Datum { get; set; }
+        public String Leiras { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/KurzusAdatok/OktatoViewModel.cs
+++ b/src/GeekPlatform/ViewModels/KurzusAdatok/OktatoViewModel.cs
@@ -8,17 +8,9 @@ namespace GeekPlatform.ViewModels.KurzusAdatok
 {
     public class OktatoViewModel
     {
-        public String Nev { get; }
-        public String Pozicio { get; }
-        public String EMail { get; }
-        public String Telefon { get; }
-
-        public OktatoViewModel(Profile profile)
-        {
-            Nev = profile.Name;
-            Pozicio = profile.Workplace;
-            EMail = profile.Email;
-            Telefon = profile.PhoneNumber;
-        }
+        public String Nev { get; set; }
+        public String Pozicio { get; set; }
+        public String EMail { get; set; }
+        public String Telefon { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Kurzusaim/KurzusTematikaViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Kurzusaim/KurzusTematikaViewModel.cs
@@ -8,13 +8,7 @@ namespace GeekPlatform.ViewModels.Kurzusaim
 {
     public class KurzusTematikaViewModel
     {
-        public String Temakor { get; }
-        public String Datum { get; }
-
-        public KurzusTematikaViewModel(CourseThematics tematika)
-        {
-            Temakor = tematika.Title;
-            Datum = tematika.ActualDate.ToString("yyyy.MM.dd. H:mm");
-        }
+        public String Temakor { get; set; }
+        public String Datum { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Kurzusaim/KurzusViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Kurzusaim/KurzusViewModel.cs
@@ -1,5 +1,4 @@
-﻿using GeekPlatform.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,26 +7,10 @@ namespace GeekPlatform.ViewModels.Kurzusaim
 {
     public class KurzusViewModel
     {
-        public String Nev { get; }
-        public String Leiras { get; }
-        public KurzusTematikaViewModel AktualisTematika { get; }
-        public KurzusTematikaViewModel KovetkezoTematika { get; }
-
-        public KurzusViewModel(Course kurzus)
-        {
-            Nev = kurzus.CourseName;
-            Leiras = kurzus.DescriptionLong;
-
-            CourseThematics aktualisTematika = kurzus.CourseThematics.Where(t => t.ActualDate < DateTime.Now).LastOrDefault();
-            CourseThematics kovetkezoTematika = kurzus.CourseThematics.Where(t => t.ActualDate > DateTime.Now).FirstOrDefault();
-            if (aktualisTematika != null)
-            {
-                AktualisTematika = new KurzusTematikaViewModel(aktualisTematika); 
-            }
-            if (kovetkezoTematika != null)
-            {
-                KovetkezoTematika = new KurzusTematikaViewModel(kovetkezoTematika); 
-            }
-        }
+        public String Nev { get; set; }
+        public String Leiras { get; set; }
+        public KurzusTematikaViewModel AktualisTematika { get; set; }
+        public KurzusTematikaViewModel KovetkezoTematika { get; set; }
+        
     }
 }

--- a/src/GeekPlatform/ViewModels/Kurzusaim/KurzusaimViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Kurzusaim/KurzusaimViewModel.cs
@@ -11,7 +11,7 @@ namespace GeekPlatform.ViewModels.Kurzusaim
         public IEnumerable<KurzusViewModel> AktivKurzusok { get; }
         public IEnumerable<KurzusViewModel> PasszivKurzusok { get; }
 
-        public KurzusaimViewModel(IEnumerable<Course> aktivKurzusok, IEnumerable<Course> passzivkurzusok, Profile user) : base(user)
+        public KurzusaimViewModel(IEnumerable<Course> aktivKurzusok, IEnumerable<Course> passzivkurzusok)
         {
                 AktivKurzusok = aktivKurzusok.Select(a => new KurzusViewModel(a)).ToList();
                 PasszivKurzusok = passzivkurzusok.Select(p => new KurzusViewModel(p)).ToList();

--- a/src/GeekPlatform/ViewModels/Kurzusaim/KurzusaimViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Kurzusaim/KurzusaimViewModel.cs
@@ -8,13 +8,7 @@ namespace GeekPlatform.ViewModels.Kurzusaim
 {
     public class KurzusaimViewModel : ViewModelBase
     {
-        public IEnumerable<KurzusViewModel> AktivKurzusok { get; }
-        public IEnumerable<KurzusViewModel> PasszivKurzusok { get; }
-
-        public KurzusaimViewModel(IEnumerable<Course> aktivKurzusok, IEnumerable<Course> passzivkurzusok)
-        {
-                AktivKurzusok = aktivKurzusok.Select(a => new KurzusViewModel(a)).ToList();
-                PasszivKurzusok = passzivkurzusok.Select(p => new KurzusViewModel(p)).ToList();
-        }
+        public IEnumerable<KurzusViewModel> AktivKurzusok { get; set; }
+        public IEnumerable<KurzusViewModel> PasszivKurzusok { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Profil/KompetenciaViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Profil/KompetenciaViewModel.cs
@@ -8,14 +8,7 @@ namespace GeekPlatform.ViewModels.Profil
 {
     public class KompetenciaViewModel
     {
-        public string KompetenciaNev { get; }
-        public int KompetenciaSzint { get; }
-
-        public KompetenciaViewModel(MemberCompetency m)
-        {
-            KompetenciaNev = m.Competency.CompetencyName;
-            KompetenciaSzint = m.CompetencyLvl;
-    }
-        
+        public string KompetenciaNev { get; set; }
+        public int KompetenciaSzint { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Profil/KurzusViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Profil/KurzusViewModel.cs
@@ -8,12 +8,6 @@ namespace GeekPlatform.ViewModels.Profil
 {
     public class KurzusViewModel
     {
-        public string KurzusNev { get; }
-
-        public KurzusViewModel(Course c)
-        {
-            KurzusNev = c.CourseName;
-
-        }
+        public string KurzusNev { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/Profil/ProfilViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Profil/ProfilViewModel.cs
@@ -8,7 +8,7 @@ namespace GeekPlatform.ViewModels.Profil
 {
     public class ProfilViewModel : ViewModelBase
     {
-        public ProfilViewModel(Profile user) : base(user)
+        public ProfilViewModel(Profile user)
         {
             Nev = user.Name;
             PozicioTeamTagsag = user.TeamMember;

--- a/src/GeekPlatform/ViewModels/Profil/ProfilViewModel.cs
+++ b/src/GeekPlatform/ViewModels/Profil/ProfilViewModel.cs
@@ -8,42 +8,21 @@ namespace GeekPlatform.ViewModels.Profil
 {
     public class ProfilViewModel : ViewModelBase
     {
-        public ProfilViewModel(Profile user)
-        {
-            Nev = user.Name;
-            PozicioTeamTagsag = user.TeamMember;
-            TagsagKezdete = user.MembershipStart;
-            /*TagsagVege =user.*/
-            Munkahely = user.Workplace;
-            Email = user.Email;
-            Slack = user.Slack;
-            TartozkodasiHely = user.Address;
-            Ajandek = user.Birthday;
-            Telefonszam = user.PhoneNumber;
-            Skype = user.Skype;
+        public string Nev { get; set; }
+        public string PozicioTeamTagsag {get; set; }
+        public DateTime TagsagKezdete { get; set; }
+        public DateTime TagsagVege { get; set; }
+        public string Munkahely { get; set; }
+        public string Email { get; set; }
+        public string Slack { get; set; }
+        public string TartozkodasiHely { get; set; }
+        public DateTime? Ajandek { get; set; }
+        public string Telefonszam { get; set; }
+        public string Skype { get; set; } 
 
-            var kurzusok = user.CourseEnrollment.Where(ce => ce.Course.IsActive).ToList();
+        public IEnumerable<KurzusViewModel> AktivKurzus { get; set; }
+        public IEnumerable<KurzusViewModel> ElvegezettKurzus { get; set; }
 
-            AktivKurzus = kurzusok.Where(ce => ce.Course.IsRunning).Select(ce => new KurzusViewModel(ce.Course));
-            ElvegezettKurzus = kurzusok.Where(ce => !ce.Course.IsRunning).Select(ce => new KurzusViewModel(ce.Course));
-            Kompetencia = user.MemberCompetency.Select(mc => new KompetenciaViewModel(mc));
-        }
-
-        public string Nev { get; }
-        public string PozicioTeamTagsag {get;}
-        public DateTime TagsagKezdete { get; }
-        public DateTime TagsagVege { get; }
-        public string Munkahely { get; }
-        public string Email { get; }
-        public string Slack { get; }
-        public string TartozkodasiHely { get;}
-        public DateTime? Ajandek { get; }
-        public string Telefonszam { get; }
-        public string Skype { get; } 
-
-        public IEnumerable<KurzusViewModel> AktivKurzus { get; }
-        public IEnumerable<KurzusViewModel> ElvegezettKurzus { get; }
-
-        public IEnumerable<KompetenciaViewModel> Kompetencia { get; }
+        public IEnumerable<KompetenciaViewModel> Kompetencia { get; set; }
     }
 }

--- a/src/GeekPlatform/ViewModels/ViewModelBase.cs
+++ b/src/GeekPlatform/ViewModels/ViewModelBase.cs
@@ -8,11 +8,10 @@ namespace GeekPlatform.ViewModels
 {
     public class ViewModelBase
     {
-        public String FelhasznaloNev { get; }
+        public Profile User { get; set; }
 
-        public ViewModelBase(Profile user)
-        {
-            FelhasznaloNev = user.Name;
-        }
+        public string ControllerNev { get; set; }
+
+        public String FelhasznaloNev => User.Name;
     }
 }

--- a/src/GeekPlatform/ViewModels/ViewModelBase.cs
+++ b/src/GeekPlatform/ViewModels/ViewModelBase.cs
@@ -8,10 +8,9 @@ namespace GeekPlatform.ViewModels
 {
     public class ViewModelBase
     {
-        public Profile User { get; set; }
 
         public string ControllerNev { get; set; }
 
-        public String FelhasznaloNev => User.Name;
+        public String FelhasznaloNev { get; set; }
     }
 }


### PR DESCRIPTION
Egyrészt SRP, másrészt praktikus okai is vannak, hogy mindenki így csinálja:
Pl. a ControllerNev-et meg bármi hasonlót így sokkal könnyebb kitölteni ControllerBase-ben, emiatt a VMB-nek lehet parameterless konstruktora ami a gyerek-viewmodellek készítésekor sokkal elegánsabb. 
Később amikor csinálunk edit formokat, akkor az EF Model Binding-jához is jól fog jönni (a default model bindernek követelménye hogy legyen parameterless constructor és setter minden public propertyn)